### PR TITLE
Pulled the installation of CURL and GIT from the ZSH install function

### DIFF
--- a/env/functions.sh
+++ b/env/functions.sh
@@ -33,10 +33,24 @@ box_install_memcached() {
     output $GREEN "Memcached installed."
 }
 
+#Install CURL
+box_install_curl() {
+    output $BLUE "Installing CURL..."
+    apt-get -qq -y install curl
+    output $GREEN "CURL installed."
+}
+
+#Install Git
+box_install_git() {
+    output $BLUE "Installing Git..."
+    apt-get -qq -y install git
+    output $GREEN "Git installed."
+}
+
 # Install ZSH
 box_install_zsh() {
     output $BLUE "Installing ZSH and oh-my-zsh..."
-    apt-get -qq -y install curl git zsh
+    apt-get -qq -y install zsh
     chsh -s /bin/zsh vagrant
     curl -s -L https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh | sh
     sed -i 's/robbyrussell/agnoster/' /root/.zshrc

--- a/env/provision-apache2.sh
+++ b/env/provision-apache2.sh
@@ -32,6 +32,9 @@ fi
 export DEBIAN_FRONTEND=noninteractive
 box_update
 
+box_install_curl
+box_install_git
+
 # # --Install required software
 output $BLUE "Installing software..."
 apt-get -qq -y install apache2 mysql-server php5 php5-cli php5-mysql $PHP_EXTRA_MODULES

--- a/env/provision-nginx.sh
+++ b/env/provision-nginx.sh
@@ -33,6 +33,9 @@ fi
 export DEBIAN_FRONTEND=noninteractive
 box_update
 
+box_install_curl
+box_install_git
+
 # # --Install required software
 output $BLUE "Installing software..."
 apt-get -qq -y install nginx mysql-server php5 php5-cgi php5-cli php5-mysql spawn-fcgi $PHP_EXTRA_MODULES


### PR DESCRIPTION
I wasn't using ZSH and was wondering why Curl (composer) and Git weren't available....i've now loosened them from ZSH if that's okay?
